### PR TITLE
Add deployToken option for firebase for use with multiple accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 This plugin will deploy your ember-cli app to firebase hosting.
 
-## What is an ember-cli-deploy plugin?
+## What is an ember-cli-deploy plugin? ##
 
 A plugin is an addon that can be executed as a part of the ember-cli-deploy pipeline. A plugin will implement one or more of the ember-cli-deploy's pipeline hooks.
 
 For more information on what plugins are and how they work, please refer to the [Plugin Documentation][1].
 
-## Compatibility
+## Compatibility ##
 
 If you need to continue using firebase 2.x, please use the 0.1.x branch.
 
-## Quick Start
+## Quick Start ##
 To get up and running quickly, do the following:
 
 - [Sign up for a Firebase account](https://www.firebase.com/signup/)
@@ -56,7 +56,7 @@ $ ember deploy production
 $ firebase open hosting:site
 ```
 
-## Installation
+## Installation ##
 Run the following commands in your terminal:
 
 ```bash
@@ -64,25 +64,52 @@ ember install ember-cli-deploy
 ember install ember-cli-deploy-firebase
 ```
 
-## ember-cli-deploy Hooks Implemented
+## ember-cli-deploy Hooks Implemented ##
 
 For detailed information on what plugin hooks are and how they work, please refer to the [Plugin Documentation][1].
 
 - `upload`
 
-## Configuration Options
+## Configuration Options ##
 
 For detailed information on how configuration of plugins works, please refer to the [Plugin Documentation][1].
 
-### fireBaseAppName
+### firebase.appName ###
 
 The name of the firebase app you want to deploy to. If not specified, firebase-tools will pick this up from the `firebase.json` file it created in your project directory.
 
 ```
-ENV.fireBaseAppName: 'your-firebase-app-name';
+ENV = {
+  ...
+  firebase: {
+    appName: 'your-firebase-app-name'
+  },
+  ...
+};
 ```
 
-### build.outputPath
+### firebase.deployToken ###
+
+If you have multiple firebase users, it's helpful to use a token instead. You can set
+```
+ENV = {
+  ...
+  firebase: {
+    deployToken: 'asdf1234'
+  },
+  ...
+};
+```
+
+replacing 'asdf1234' with the ```firebase login:ci``` token you receive.
+
+More highly recommended:
+1. Create a .env file in your project root and add ```FIREBASE_DEPLOY_TOKEN="ASDF1234"``` to it, where "ASDF1234" is the ```firebase login:ci``` token you received.
+2. In config/deploy.js, add ```ENV.firebase.deployToken = process.env.FIREBASE_DEPLOY_TOKEN```
+
+After this you should be able to deploy regardless of what account is currently logged in.
+
+### build.outputPath ###
 
 If you have customised the location your builds go, we'll pass that on.
 

--- a/README.md
+++ b/README.md
@@ -89,25 +89,30 @@ ENV = {
 ```
 
 ### firebase.deployToken ###
+If you have multiple firebase users, it's helpful to use a token instead.
 
-If you have multiple firebase users, it's helpful to use a token instead. You can set
+#### Option 1 (Recommended) ####
+1. Run ```firebase login:ci``` and add the code to your ~/.bashrc or ~/.profile: ```export FIREBASE_TOKEN=ASDF1234```, replacing ASDF1234 with whatever token you received from the previous command.
+2. Run ```source ~/.bashrc``` or ```source ~/.profile``` depending on the above.
+3. Congrats! Your project should run ```ember deploy production``` as well as other firebase-tools commands successfully, no addition to config/deploy.js needed.
+4. You can always still add ```ENV.firebase.deployToken = process.env.FIREBASE_TOKEN``` but it is not necessary.
+
+#### Option 2 ####
+1. Run ```firebase login:ci``` and copy the code you receive.
+2. (optional) Create a file in the project root ```.env.deploy.production``` and add ```FIREBASE_TOKEN=ASDF1234``` replacing ASDF1234 with the code from step 1.
+3. In config/deploy.js
 ```
 ENV = {
   ...
   firebase: {
     deployToken: 'asdf1234'
+    // deployToken: process.env.FIREBASE_TOKEN (if .env stuff is your style)
   },
   ...
 };
 ```
 
-replacing 'asdf1234' with the ```firebase login:ci``` token you receive.
-
-More highly recommended:
-1. Create a .env file in your project root and add ```FIREBASE_DEPLOY_TOKEN="ASDF1234"``` to it, where "ASDF1234" is the ```firebase login:ci``` token you received.
-2. In config/deploy.js, add ```ENV.firebase.deployToken = process.env.FIREBASE_DEPLOY_TOKEN```
-
-After this you should be able to deploy regardless of what account is currently logged in.
+**After this you should be able to deploy regardless of what account is currently logged in.**
 
 ### build.outputPath ###
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ module.exports = {
           public: context.config.build.outputPath,
           message: (context.revisionData || {}).revisionKey
         };
-        if (context.config.firebase.deployToken) {
-          options.token = context.config.firebase.deployToken;
+        if (context.config.firebase.deployToken || process.env.FIREBASE_TOKEN) {
+          options.token = context.config.firebase.deployToken || process.env.FIREBASE_TOKEN;
         }
         return fbTools.deploy(options).then(function() {
           // outer.log('it worked yay');

--- a/index.js
+++ b/index.js
@@ -12,11 +12,15 @@ module.exports = {
 
       upload: function(context) {
         var outer = this;
+        var project = context.config.firebase.appName || context.config.fireBaseAppName;
         var options = {
-          project: context.config.fireBaseAppName,
+          project: project,
           public: context.config.build.outputPath,
           message: (context.revisionData || {}).revisionKey
         };
+        if (context.config.firebase.deployToken) {
+          options.token = context.config.firebase.deployToken;
+        }
         return fbTools.deploy(options).then(function() {
           // outer.log('it worked yay');
         }).catch(function(err) {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -50,7 +50,14 @@ describe('firebase plugin', function() {
       context = {
         ui: mockUi,
         project: stubProject,
-        config: { fireBaseAppName: 'dont-test-me', build: {outputPath: './dist'},}
+        config: {
+          fireBaseAppName: 'dont-test-me',
+          firebase: {
+            appName: 'dont-test-me-object',
+            deployToken: 'deploy-token-1234'
+          },
+          build: {outputPath: './dist'},
+        }
       };
       return plugin.upload(context).should.be.fulfilled;
     });


### PR DESCRIPTION
Additionally, change fireBaseAppName to firebase.appName to fit with config hash. **Does not break 'context.config.fireBaseAppName'**